### PR TITLE
Remove not supported Python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,6 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
 
 [files]
 packages =


### PR DESCRIPTION
Only Python 2 (therefore Python 2.7) is supported and tested, so it
should be the only one advertised in the setup.cfg file.
