### PR TITLE
Add unit testing for all modules

### DIFF
--- a/opie/scheduler/filter_scheduler.py
+++ b/opie/scheduler/filter_scheduler.py
@@ -127,6 +127,17 @@ class FilterScheduler(nova_filter_scheduler.FilterScheduler):
         """Select preemptible instances to be killed for the request."""
         preemptibles = [i for i in host.instances.values()
                  if i.system_metadata.get("preemptible")]
+        if not preemptibles:
+            # Log the details but don't put those into the reason since
+            # we don't want to give away too much information about our
+            # actual environment.
+            LOG.debug('Need to terminate preemptible instances, but there'
+                      'are no preemptible instances on %(host)s' %
+                      {'host': host})
+
+            reason = _('Cannot terminate enough preemptible instances.')
+            raise exception.NoValidHost(reason=reason)
+
         # FIXME(aloga): This needs to be fixed, as we are assuming that killing
         # one instance will free enough resources
         return [preemptibles.pop()]

--- a/opie/scheduler/filter_scheduler.py
+++ b/opie/scheduler/filter_scheduler.py
@@ -133,21 +133,21 @@ class FilterScheduler(nova_filter_scheduler.FilterScheduler):
 
     def detect_overcommit(self, host):
         """Detect overcommit of resources, according to configured ratios."""
-        if host.free_ram_mb < 0:
-            ram_limit = host.total_usable_ram_mb * CONF.ram_allocation_ratio
-            used_ram = host.total_usable_ram_mb + (-host.free_ram_mb)
-            if used_ram > ram_limit:
-                return True
+        ram_limit = host.total_usable_ram_mb * host.ram_allocation_ratio
+        used_ram = host.total_usable_ram_mb - host.free_ram_mb
+        if used_ram > ram_limit:
+            return True
 
-        if host.free_disk_mb < 0:
-            disk_limit = host.total_usable_disk_gb * CONF.disk_allocation_ratio
-            used_disk = host.total_usable_disk_gb - host.free_disk_mb / 1024.
-            if used_disk > disk_limit:
-                return True
+        disk_limit = host.total_usable_disk_gb * CONF.disk_allocation_ratio
+        used_disk = host.total_usable_disk_gb - host.free_disk_mb / 1024.
+        if used_disk > disk_limit:
+            return True
 
-        cpus_limit = host.vcpus_total * CONF.cpu_allocation_ratio
+        cpus_limit = host.vcpus_total * host.cpu_allocation_ratio
         if host.vcpus_used > cpus_limit:
             return True
+
+        return False
 
     def _schedule(self, context, request_spec, filter_properties):
         """Returns a list of hosts that meet the required specs,

--- a/opie/scheduler/filter_scheduler.py
+++ b/opie/scheduler/filter_scheduler.py
@@ -273,7 +273,7 @@ class FilterScheduler(nova_filter_scheduler.FilterScheduler):
         # NOTE(aloga): this should be removed from here. We should get it from
         # the instance, so that we could change how a preemptible instance is
         # identified.
-        instance_properties = request_spec['instance_properties']
-        if instance_properties['system_metadata'].get('preemptible'):
+        instance_properties = request_spec.get('instance_properties', {})
+        if instance_properties.get('system_metadata', {}).get('preemptible'):
             return True
         return False

--- a/opie/tests/test_hostmanager.py
+++ b/opie/tests/test_hostmanager.py
@@ -1,0 +1,332 @@
+# Copyright 2016 Spanish National Research Council - CSIC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from opie.scheduler import host_manager
+
+import mock
+from nova.compute import task_states
+from nova.compute import vm_states
+import nova.objects
+from nova.objects import base as obj_base
+from nova.scheduler import host_manager as nova_host_manager
+from nova import test as nova_test
+from nova.tests import fixtures
+from nova.tests.unit import fake_instance
+from nova.tests.unit import matchers
+from nova.tests.unit.scheduler import fakes
+from nova.tests.unit.scheduler import test_host_manager \
+        as nova_test_host_manager
+
+# The nova HostManager tests are checking that the apporpiate logging messages
+# are emited for some warnings and failures. The tests are making an
+# mox.StubOutWithMock on the host_manager.LOG.warning methods, that is not the
+# LOG object used by opie, so we need to replace the nova one with the opie one
+nova_host_manager.LOG = host_manager.LOG
+
+
+class OpieHostManagerTestCase(nova_test_host_manager.HostManagerTestCase):
+    """Test case for opie HostManager class."""
+
+    @mock.patch.object(host_manager.HostManager, '_init_instance_info')
+    @mock.patch.object(host_manager.HostManager, '_init_aggregates')
+    def setUp(self, mock_init_agg, mock_init_inst):
+        super(OpieHostManagerTestCase, self).setUp()
+        self.host_manager = host_manager.HostManager()
+
+        self.fake_hosts = [nova_host_manager.HostState('fake_host%s' % x,
+                'fake-node') for x in range(1, 5)]
+        self.fake_hosts += [nova_host_manager.HostState('fake_multihost',
+                'fake-node%s' % x) for x in range(1, 5)]
+
+        self.useFixture(fixtures.SpawnIsSynchronousFixture())
+
+    @mock.patch('opie.scheduler.host_manager.LOG')
+    @mock.patch('nova.objects.ServiceList.get_by_binary')
+    @mock.patch('nova.objects.ComputeNodeList.get_all')
+    @mock.patch.object(nova.objects.InstanceList, 'get_by_host')
+    def test_get_all_host_partial_states(self, mock_get_by_host, mock_get_all,
+                                         mock_get_by_binary, mock_log):
+        mock_get_by_host.return_value = nova.objects.InstanceList()
+        mock_get_all.return_value = fakes.COMPUTE_NODES
+        mock_get_by_binary.return_value = fakes.SERVICES
+        context = 'fake_context'
+
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 4)
+
+        calls = [
+            mock.call(
+                "No compute service record found for host %(host)s",
+                {'host': 'fake'}
+            )
+        ]
+        self.assertEqual(calls, mock_log.warning.call_args_list)
+
+        # Check that .service is set properly
+        for i in range(4):
+            compute_node = fakes.COMPUTE_NODES[i]
+            host = compute_node['host']
+            node = compute_node['hypervisor_hostname']
+            state_key = (host, node)
+            self.assertEqual(host_states_map[state_key].service,
+                    obj_base.obj_to_primitive(fakes.get_service_by_host(host)))
+        self.assertEqual(host_states_map[('host1', 'node1')].free_ram_mb,
+                         512)
+        # 511GB
+        self.assertEqual(host_states_map[('host1', 'node1')].free_disk_mb,
+                         524288)
+        self.assertEqual(host_states_map[('host2', 'node2')].free_ram_mb,
+                         1024)
+        # 1023GB
+        self.assertEqual(host_states_map[('host2', 'node2')].free_disk_mb,
+                         1048576)
+        self.assertEqual(host_states_map[('host3', 'node3')].free_ram_mb,
+                         3072)
+        # 3071GB
+        self.assertEqual(host_states_map[('host3', 'node3')].free_disk_mb,
+                         3145728)
+        self.assertThat(
+                nova.objects.NUMATopology.obj_from_db_obj(
+                        host_states_map[('host3', 'node3')].numa_topology
+                    )._to_dict(),
+                matchers.DictMatches(fakes.NUMA_TOPOLOGY._to_dict()))
+        self.assertEqual(host_states_map[('host4', 'node4')].free_ram_mb,
+                         8192)
+        # 8191GB
+        self.assertEqual(host_states_map[('host4', 'node4')].free_disk_mb,
+                         8388608)
+
+
+class OpieHostManagerChangedNodesTestCase(nova_test_host_manager.
+                                            HostManagerChangedNodesTestCase):
+    """Test case for opie HostManager class."""
+
+    @mock.patch.object(host_manager.HostManager, '_init_instance_info')
+    @mock.patch.object(host_manager.HostManager, '_init_aggregates')
+    def setUp(self, mock_init_agg, mock_init_inst):
+        super(OpieHostManagerChangedNodesTestCase, self).setUp()
+        self.host_manager = host_manager.HostManager()
+        self.fake_hosts = [
+              nova_host_manager.HostState('host1', 'node1'),
+              nova_host_manager.HostState('host2', 'node2'),
+              nova_host_manager.HostState('host3', 'node3'),
+              nova_host_manager.HostState('host4', 'node4')
+            ]
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary')
+    @mock.patch('nova.objects.ComputeNodeList.get_all')
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    def test_get_all_host_partial_states(self, mock_get_by_host, mock_get_all,
+                                         mock_get_by_binary):
+        mock_get_by_host.return_value = nova.objects.InstanceList()
+        mock_get_all.return_value = fakes.COMPUTE_NODES
+        mock_get_by_binary.return_value = fakes.SERVICES
+        context = 'fake_context'
+
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 4)
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary')
+    @mock.patch('nova.objects.ComputeNodeList.get_all')
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    def test_get_all_host_states_after_delete_one(self, mock_get_by_host,
+                                                  mock_get_all,
+                                                  mock_get_by_binary):
+        getter = (lambda n: n.hypervisor_hostname
+                  if 'hypervisor_hostname' in n else None)
+        running_nodes = [n for n in fakes.COMPUTE_NODES
+                         if getter(n) != 'node4']
+
+        mock_get_by_host.return_value = nova.objects.InstanceList()
+        mock_get_all.side_effect = [fakes.COMPUTE_NODES, running_nodes]
+        mock_get_by_binary.side_effect = [fakes.SERVICES, fakes.SERVICES]
+        context = 'fake_context'
+
+        # first call: all nodes
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 4)
+
+        # second call: just running nodes
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 3)
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary')
+    @mock.patch('nova.objects.ComputeNodeList.get_all')
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    def test_get_all_host_partial_states_after_delete_all(self,
+                                                          mock_get_by_host,
+                                                          mock_get_all,
+                                                          mock_get_by_binary):
+        mock_get_by_host.return_value = nova.objects.InstanceList()
+        mock_get_all.side_effect = [fakes.COMPUTE_NODES, []]
+        mock_get_by_binary.side_effect = [fakes.SERVICES, fakes.SERVICES]
+        context = 'fake_context'
+
+        # first call: all nodes
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 4)
+
+        # second call: no nodes
+        self.host_manager.get_all_host_partial_states(context)
+        host_states_map = self.host_manager.host_state_map
+        self.assertEqual(len(host_states_map), 0)
+
+
+class OpieHostStateTestCase(nova_test.NoDBTestCase):
+    """Test case for Opie HostStatePartial class."""
+
+    # update_from_compute_node() and consume_from_instance() are tested
+    # in HostManagerTestCase.test_get_all_host_states()
+
+    @mock.patch('nova.virt.hardware.get_host_numa_usage_from_instance')
+    @mock.patch('nova.virt.hardware.numa_fit_instance_to_host')
+    @mock.patch('nova.virt.hardware.instance_topology_from_instance')
+    @mock.patch('nova.virt.hardware.host_topology_and_format_from_host')
+    def test_stat_consumption_from_instance(self, host_topo_mock,
+                                            instance_topo_mock,
+                                            numa_fit_mock,
+                                            numa_usage_mock):
+        fake_numa_topology = mock.Mock()
+        host_topo_mock.return_value = ('fake-host-topology', None)
+        numa_usage_mock.return_value = 'fake-consumed-once'
+        numa_fit_mock.return_value = 'fake-fitted-once'
+        instance_topo_mock.return_value = fake_numa_topology
+        instance = dict(root_gb=0, ephemeral_gb=0, memory_mb=0, vcpus=0,
+                        project_id='12345', vm_state=vm_states.BUILDING,
+                        task_state=task_states.SCHEDULING, os_type='Linux',
+                        uuid='fake-uuid',
+                        numa_topology=fake_numa_topology,
+                        pci_requests={'requests': []})
+        host = host_manager.HostStatePartial("fakehost", "fakenode")
+
+        self.assertIsNone(host.updated)
+        host.consume_from_instance(instance)
+        numa_fit_mock.assert_called_once_with('fake-host-topology',
+                                              fake_numa_topology,
+                                              limits=None, pci_requests=None,
+                                              pci_stats=None)
+        numa_usage_mock.assert_called_once_with(host, instance)
+        self.assertEqual('fake-consumed-once', host.numa_topology)
+        self.assertEqual('fake-fitted-once', instance['numa_topology'])
+        self.assertIsNotNone(host.updated)
+
+        instance = dict(root_gb=0, ephemeral_gb=0, memory_mb=0, vcpus=0,
+                        project_id='12345', vm_state=vm_states.ACTIVE,
+                        task_state=task_states.RESIZE_PREP, os_type='Linux',
+                        uuid='fake-uuid',
+                        numa_topology=fake_numa_topology)
+        numa_usage_mock.return_value = 'fake-consumed-twice'
+        numa_fit_mock.return_value = 'fake-fitted-twice'
+        host.consume_from_instance(instance)
+        self.assertEqual('fake-fitted-twice', instance['numa_topology'])
+
+        self.assertEqual(2, host.num_instances)
+        self.assertEqual(2, host.num_io_ops)
+        self.assertEqual(2, numa_usage_mock.call_count)
+        self.assertEqual(((host, instance),), numa_usage_mock.call_args)
+        self.assertEqual('fake-consumed-twice', host.numa_topology)
+        self.assertIsNotNone(host.updated)
+
+    @mock.patch('nova.virt.hardware.get_host_numa_usage_from_instance')
+    @mock.patch('nova.virt.hardware.numa_fit_instance_to_host')
+    @mock.patch('nova.virt.hardware.instance_topology_from_instance')
+    @mock.patch('nova.virt.hardware.host_topology_and_format_from_host')
+    def test_stat_unconsumption_from_instance(self, host_topo_mock,
+                                            instance_topo_mock,
+                                            numa_fit_mock,
+                                            numa_usage_mock):
+        fake_numa_topology = mock.Mock()
+        host_topo_mock.return_value = ('fake-host-topology', None)
+        instance_topo_mock.return_value = fake_numa_topology
+
+        instance = dict(root_gb=0, ephemeral_gb=0, memory_mb=0, vcpus=0,
+                        project_id='12345', vm_state=vm_states.BUILDING,
+                        task_state=task_states.SCHEDULING, os_type='Linux',
+                        uuid='fake-uuid',
+                        numa_topology=fake_numa_topology,
+                        pci_requests={'requests': []})
+        host = host_manager.HostStatePartial("fakehost", "fakenode")
+
+        self.assertIsNone(host.updated)
+        host.consume_from_instance(instance)
+        self.assertEqual(1, host.num_instances)
+        self.assertIsNotNone(host.updated)
+
+        instance = dict(root_gb=1, ephemeral_gb=1, memory_mb=3, vcpus=4,
+                        project_id='12345', vm_state=vm_states.ACTIVE,
+                        task_state=task_states.RESIZE_PREP, os_type='Linux',
+                        uuid='fake-uuid',
+                        numa_topology=fake_numa_topology,
+                        system_metadata={"preemptible": True})
+        host.consume_from_instance(instance)
+        self.assertEqual(2, host.num_instances)
+
+        host._unconsume_from_instance(instance)
+        self.assertEqual(1, host.num_instances)
+        self.assertEqual(2, host.num_io_ops)
+        self.assertEqual(0, host.free_disk_mb)
+        self.assertEqual(0, host.free_ram_mb)
+        self.assertEqual(0, host.vcpus_used)
+        self.assertIsNotNone(host.updated)
+
+    def test_stat_unconsumption_from_instance_list(self):
+
+        instances = {}
+        inst = fake_instance.fake_instance_obj(
+            "fake context", root_gb=0, ephemeral_gb=0, memory_mb=0, vcpus=0,
+            project_id='12345', vm_state=vm_states.BUILDING,
+            task_state=task_states.SCHEDULING, os_type='Linux',
+            uuid='fake-uuid-normal'
+        )
+        # Set this attribute here instead of doing a mock with the DB object
+        inst.system_metadata = {}
+        instances[inst.uuid] = inst
+
+        inst = fake_instance.fake_instance_obj(
+            "fake context", root_gb=1, ephemeral_gb=1, memory_mb=3, vcpus=4,
+            project_id='12345', vm_state=vm_states.ACTIVE,
+            task_state=task_states.RESIZE_PREP, os_type='Linux',
+            uuid='fake-uuid-preemptible'
+        )
+        inst.system_metadata = {"preemptible": True}
+        instances[inst.uuid] = inst
+
+        host = host_manager.HostStatePartial("fakehost", "fakenode")
+
+        self.assertIsNone(host.updated)
+        # Instances consume resources in the scheduling loop
+        for instance in instances.values():
+            host.consume_from_instance(instance)
+
+        host.instances = instances
+        self.assertEqual(1, host.num_instances)
+        self.assertEqual(0, host.num_io_ops)
+        self.assertEqual(0, host.free_disk_mb)
+        self.assertEqual(0, host.free_ram_mb)
+        self.assertEqual(0, host.vcpus_used)
+        self.assertIsNotNone(host.updated)
+        self.assertIn('fake-uuid-normal', host.normal_instances)
+        self.assertIn('fake-uuid-normal', host.instances)
+        self.assertIn('fake-uuid-preemptible', host.preemptible_instances)
+        self.assertIn('fake-uuid-preemptible', host.instances)
+
+        # Setting the instances a second time should leave the resources as
+        # they were
+        host.instances = instances
+        self.assertEqual(1, host.num_instances)

--- a/opie/tests/test_scheduler.py
+++ b/opie/tests/test_scheduler.py
@@ -1,0 +1,457 @@
+# Copyright 2016 Spanish National Research Council - CSIC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+
+from opie.scheduler import filter_scheduler
+
+import mock
+from nova.compute import task_states
+from nova.compute import vm_states
+from nova import exception
+from nova.scheduler import weights
+from nova.tests.unit import fake_instance
+from nova.tests.unit.scheduler import fakes
+from nova.tests.unit.scheduler import test_filter_scheduler \
+        as nova_test_filter_scheduler
+from nova.tests.unit.scheduler import test_scheduler
+
+
+class FilterSchedulerTestCase(nova_test_filter_scheduler.
+                              FilterSchedulerTestCase):
+
+    driver_cls = filter_scheduler.FilterScheduler
+
+    def setUp(self):
+        self.flags(
+            scheduler_host_manager='opie.scheduler.host_manager.HostManager'
+        )
+
+        super(FilterSchedulerTestCase, self).setUp()
+
+    @mock.patch.object(filter_scheduler.FilterScheduler, 'detect_overcommit')
+    @mock.patch.object(filter_scheduler.FilterScheduler, '_schedule')
+    def test_select_destinations_notifications(self, mock_schedule,
+                                               mock_detect):
+        mock_schedule.return_value = [mock.Mock()]
+        mock_detect.return_value = False
+
+        with mock.patch.object(self.driver.notifier, 'info') as mock_info:
+            request_spec = {'num_instances': 1}
+
+            self.driver.select_destinations(self.context, request_spec, {})
+
+            expected = [
+                mock.call(self.context, 'scheduler.select_destinations.start',
+                 dict(request_spec=request_spec)),
+                mock.call(self.context, 'scheduler.select_destinations.end',
+                 dict(request_spec=request_spec))]
+            self.assertEqual(expected, mock_info.call_args_list)
+
+
+class OpieFilterSchedulerTestCase(test_scheduler.SchedulerTestCase):
+    driver_cls = filter_scheduler.FilterScheduler
+
+    def setUp(self):
+        self.flags(
+            scheduler_host_manager='opie.scheduler.host_manager.HostManager'
+        )
+
+        super(OpieFilterSchedulerTestCase, self).setUp()
+
+    def test_detect_preemptible(self):
+        # FIXME(aloga): Right now this is almost useless. We should get the
+        # request spect from the compute API, so that if we modify it there we
+        # are able to detect it here...
+        request_spec = {
+            'instance_properties': {
+                'system_metadata': {
+                    'preemptible': True,
+                }
+            }
+        }
+
+        self.assertTrue(self.driver._is_preemptible_request(request_spec))
+
+    def test_detect_preemptible_false(self):
+        # FIXME(aloga): Right now this is almost useless. We should get the
+        # request spect from the compute API, so that if we modify it there we
+        # are able to detect it here...
+        request_spec = {
+            'instance_properties': {
+                'system_metadata': {
+                    'preemptible': False,
+                }
+            }
+        }
+
+        self.assertFalse(self.driver._is_preemptible_request(request_spec))
+
+    def test_detect_preemptible_empty(self):
+        # FIXME(aloga): Right now this is almost useless. We should get the
+        # request spect from the compute API, so that if we modify it there we
+        # are able to detect it here...
+        request_spec = {}
+
+        self.assertFalse(self.driver._is_preemptible_request(request_spec))
+
+    def test_detect_overcommit_ram(self):
+        obj = fakes.FakeHostState("host", "node",
+                                  {"free_ram_mb": -1000,
+                                   "total_usable_ram_mb": 1000,
+                                   "ram_allocation_ratio": 1.5})
+        self.assertTrue(self.driver.detect_overcommit(obj))
+
+    def test_detect_overcommit_cpu(self):
+        obj = fakes.FakeHostState("host", "node",
+                                  {"total_usable_ram_mb": 1000,
+                                   "ram_allocation_ratio": 1,
+                                   "vcpus_used": 201,
+                                   "vcpus_total": 20,
+                                   "cpu_allocation_ratio": 10})
+        self.assertTrue(self.driver.detect_overcommit(obj))
+
+    def test_detect_overcommit_disk(self):
+        self.flags(disk_allocation_ratio=0.8)
+        obj = fakes.FakeHostState("host", "node",
+                                  {"total_usable_ram_mb": 1000,
+                                   "ram_allocation_ratio": 1,
+                                   "free_disk_mb": 10 * 1024,
+                                   "total_usable_disk_gb": 100,
+                                   })
+        self.assertTrue(self.driver.detect_overcommit(obj))
+
+    def test_detect_not_overcommit(self):
+        obj = fakes.FakeHostState("host", "node",
+                                  {"free_ram_mb": 0,
+                                   "total_usable_ram_mb": 1024,
+                                   "free_disk_mb": 100,
+                                   "vcpus_used": 10,
+                                   "vcpus_total": 10,
+                                   "cpu_allocation_ratio": 1,
+                                   "ram_allocation_ratio": 1.5})
+        self.assertFalse(self.driver.detect_overcommit(obj))
+
+    def test_terminate_preemptible_instances(self):
+        ctxt = mock.Mock()
+        ctxt.elevated.return_value = "elevated"
+        instances = [{"uuid": 1}, {"uuid": 2}]
+        calls_get = [mock.call("elevated", i["uuid"], want_objects=True)
+                     for i in instances]
+        calls_delete = [mock.call("elevated", i) for i in instances]
+
+        with contextlib.nested(
+            mock.patch.object(self.driver.compute_api, "get"),
+            mock.patch.object(self.driver.compute_api, "delete")
+        ) as (mock_get, mock_delete):
+            mock_get.side_effect = instances
+            self.driver.terminate_preemptible_instances(ctxt, instances)
+            self.assertEqual(calls_get, mock_get.call_args_list)
+            self.assertEqual(calls_delete, mock_delete.call_args_list)
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary',
+                return_value=fakes.SERVICES)
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    @mock.patch('nova.objects.ComputeNodeList.get_all',
+                return_value=fakes.COMPUTE_NODES)
+    @mock.patch('nova.db.instance_extra_get_by_instance_uuid',
+                return_value={'numa_topology': None,
+                              'pci_requests': None})
+    def test_select_destinations(self, mock_get_extra, mock_get_all,
+                                            mock_by_host, mock_get_by_binary):
+        """select_destinations is basically a wrapper around _schedule().
+
+        Similar to the _schedule tests, this just does a happy path test to
+        ensure there is nothing glaringly wrong.
+        """
+
+        self.next_weight = 1.0
+
+        selected_hosts = []
+        selected_nodes = []
+
+        def _fake_weigh_objects(_self, functions, hosts, options):
+            self.next_weight += 2.0
+            host_state = hosts[0]
+            selected_hosts.append(host_state.host)
+            selected_nodes.append(host_state.nodename)
+            return [weights.WeighedHost(host_state, self.next_weight)]
+
+        self.stubs.Set(self.driver.host_manager, 'get_filtered_hosts',
+            nova_test_filter_scheduler.fake_get_filtered_hosts)
+        self.stubs.Set(weights.HostWeightHandler,
+            'get_weighed_objects', _fake_weigh_objects)
+
+        request_spec = {'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid'},
+                        'num_instances': 1}
+        self.mox.ReplayAll()
+        dests = self.driver.select_destinations(self.context, request_spec, {})
+        (host, node) = (dests[0]['host'], dests[0]['nodename'])
+        self.assertEqual(host, selected_hosts[0])
+        self.assertEqual(node, selected_nodes[0])
+
+    @mock.patch('nova.objects.ServiceList.get_by_binary',
+                return_value=fakes.SERVICES)
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    @mock.patch('nova.objects.ComputeNodeList.get_all',
+                return_value=fakes.COMPUTE_NODES)
+    @mock.patch('nova.db.instance_extra_get_by_instance_uuid',
+                return_value={'numa_topology': None,
+                              'pci_requests': None})
+    def test_select_destinations_premptible(self, mock_get_extra, mock_get_all,
+                                            mock_by_host, mock_get_by_binary):
+        """select_destinations is basically a wrapper around _schedule().
+
+        Similar to the _schedule tests, this just does a happy path test to
+        ensure there is nothing glaringly wrong.
+        """
+
+        self.next_weight = 1.0
+
+        selected_hosts = []
+        selected_nodes = []
+
+        def _fake_weigh_objects(_self, functions, hosts, options):
+            self.next_weight += 2.0
+            host_state = hosts[0]
+            selected_hosts.append(host_state.host)
+            selected_nodes.append(host_state.nodename)
+            return [weights.WeighedHost(host_state, self.next_weight)]
+
+        self.stubs.Set(self.driver.host_manager, 'get_filtered_hosts',
+            nova_test_filter_scheduler.fake_get_filtered_hosts)
+        self.stubs.Set(weights.HostWeightHandler,
+            'get_weighed_objects', _fake_weigh_objects)
+
+        request_spec = {'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid',
+                                                'system_metadata': {
+                                                    'preemptible': True
+                                                }},
+                        'num_instances': 1}
+        self.mox.ReplayAll()
+        dests = self.driver.select_destinations(self.context, request_spec, {})
+        (host, node) = (dests[0]['host'], dests[0]['nodename'])
+        self.assertEqual(host, selected_hosts[0])
+        self.assertEqual(node, selected_nodes[0])
+
+    @mock.patch('nova.scheduler.weights.HostWeightHandler.get_weighed_objects')
+    @mock.patch('opie.scheduler.host_manager.HostManager.get_filtered_hosts',
+                side_effect=nova_test_filter_scheduler.fake_get_filtered_hosts)
+    @mock.patch('nova.objects.ServiceList.get_by_binary',
+                return_value=fakes.SERVICES)
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    @mock.patch('nova.objects.ComputeNodeList.get_all',
+                return_value=fakes.COMPUTE_NODES)
+    @mock.patch('nova.db.instance_extra_get_by_instance_uuid',
+                return_value={'numa_topology': None,
+                              'pci_requests': None})
+    def test_schedule_happy_day(self, mock_get_extra, mock_get_all,
+                                mock_by_host, mock_get_by_binary,
+                                mock_get_filtered_hosts,
+                                mock_get_weighed_objects):
+        """Make sure there's nothing glaringly wrong with _schedule()
+        by doing a happy day pass through. We ensure that we are getting and
+        using the correct states (i.e. partial or not) with regards the
+        request being preemptible or not.
+        """
+
+        self.next_weight = 1.0
+
+        def _fake_weigh_objects(functions, hosts, options):
+            self.next_weight += 2.0
+            host_state = hosts[0]
+            return [weights.WeighedHost(host_state, self.next_weight)]
+
+        mock_get_weighed_objects.side_effect = _fake_weigh_objects
+
+        request_spec = {'num_instances': 10,
+                        'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid'}}
+        partial_states = list(self.driver._get_all_host_states(self.context,
+                                                               partial=True))
+        all_states = list(self.driver._get_all_host_states(self.context,
+                                                           partial=False))
+        weighed_hosts = self.driver._schedule(self.context, request_spec, {})
+
+        # the HostState and HostStatePartial are the same objects
+        mock_get_filtered_hosts.assert_called_with(partial_states,
+                                                   mock.ANY,
+                                                   index=mock.ANY)
+        mock_get_weighed_objects.assert_called_with(mock.ANY,
+                                                    all_states,
+                                                    mock.ANY)
+
+        self.assertEqual(len(weighed_hosts), 10)
+        for weighed_host in weighed_hosts:
+            self.assertIsNotNone(weighed_host.obj)
+
+    @mock.patch('nova.scheduler.weights.HostWeightHandler.get_weighed_objects')
+    @mock.patch('opie.scheduler.host_manager.HostManager.get_filtered_hosts',
+                side_effect=nova_test_filter_scheduler.fake_get_filtered_hosts)
+    @mock.patch('nova.objects.ServiceList.get_by_binary',
+                return_value=fakes.SERVICES)
+    @mock.patch('nova.objects.InstanceList.get_by_host')
+    @mock.patch('nova.objects.ComputeNodeList.get_all',
+                return_value=fakes.COMPUTE_NODES)
+    @mock.patch('nova.db.instance_extra_get_by_instance_uuid',
+                return_value={'numa_topology': None,
+                              'pci_requests': None})
+    def test_schedule_happy_day_preemptible(self, mock_get_extra, mock_get_all,
+                                            mock_by_host, mock_get_by_binary,
+                                            mock_get_filtered_hosts,
+                                            mock_get_weighed_objects):
+        """Make sure there's nothing glaringly wrong with _schedule()
+        by doing a happy day pass through. We ensure that we are getting and
+        using the correct states (i.e. partial or not) with regards the
+        request being preemptible or not.
+        """
+
+        self.next_weight = 1.0
+
+        def _fake_weigh_objects(functions, hosts, options):
+            self.next_weight += 2.0
+            host_state = hosts[0]
+            return [weights.WeighedHost(host_state, self.next_weight)]
+
+        mock_get_weighed_objects.side_effect = _fake_weigh_objects
+
+        request_spec = {'num_instances': 10,
+                        'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid',
+                                                'system_metadata': {
+                                                    'preemptible': True
+                                                }}}
+        all_states = list(self.driver._get_all_host_states(self.context,
+                                                           partial=False))
+        weighed_hosts = self.driver._schedule(self.context, request_spec, {})
+
+        # the HostState and HostStatePartial are the same objects
+        mock_get_filtered_hosts.assert_called_with(all_states,
+                                                   mock.ANY,
+                                                   index=mock.ANY)
+        mock_get_weighed_objects.assert_called_with(mock.ANY,
+                                                    all_states,
+                                                    mock.ANY)
+
+        self.assertEqual(len(weighed_hosts), 10)
+        for weighed_host in weighed_hosts:
+            self.assertIsNotNone(weighed_host.obj)
+
+    @mock.patch('opie.scheduler.filter_scheduler.FilterScheduler._schedule')
+    def test_select_destinations_kill_preemptible_empty(self, mock_schedule):
+        host = fakes.FakeHostState("host", "node",
+                                   {"free_ram_mb": -1000,
+                                    "total_usable_ram_mb": 1000,
+                                    "ram_allocation_ratio": 1.5})
+        mock_schedule.return_value = [weights.WeighedHost(host, 1)]
+        request_spec = {'num_instances': 1,
+                        'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid',
+                                                'system_metadata': {
+                                                    'preemptible': False
+                                                }}}
+        self.assertRaises(exception.NoValidHost,
+                          self.driver.select_destinations,
+                          self.context,
+                          request_spec,
+                          {})
+
+    @mock.patch('opie.scheduler.filter_scheduler.FilterScheduler.'
+                'terminate_preemptible_instances')
+    @mock.patch('opie.scheduler.filter_scheduler.FilterScheduler._schedule')
+    def test_select_destinations_kill_preemptible(self, mock_schedule,
+                                                  mock_terminate):
+        host = fakes.FakeHostState("host", "node",
+                                   {"free_ram_mb": -1000,
+                                    "total_usable_ram_mb": 1000,
+                                    "ram_allocation_ratio": 1.5})
+        instances = {
+            'uuid-preemptible': fake_instance.fake_instance_obj(
+                "fake context", root_gb=1, ephemeral_gb=1, memory_mb=3,
+                vcpus=4, project_id='12345', vm_state=vm_states.ACTIVE,
+                task_state=task_states.RESIZE_PREP, os_type='Linux',
+                uuid='uuid-preemptible'),
+            'uuid-normal': fake_instance.fake_instance_obj(
+                "fake context", root_gb=1, ephemeral_gb=1, memory_mb=3,
+                vcpus=4, project_id='12345', vm_state=vm_states.ACTIVE,
+                task_state=task_states.RESIZE_PREP, os_type='Linux',
+                uuid='uuid-preemptible')
+        }
+        instances['uuid-normal'].system_metadata = {"preemptible": False}
+        instances['uuid-preemptible'].system_metadata = {"preemptible": True}
+        host.instances = instances
+
+        mock_schedule.return_value = [weights.WeighedHost(host, 1)]
+        mock_terminate.return_value = None
+
+        request_spec = {'num_instances': 1,
+                        'instance_type': {'memory_mb': 512, 'root_gb': 512,
+                                          'ephemeral_gb': 0,
+                                          'vcpus': 1},
+                        'instance_properties': {'project_id': 1,
+                                                'root_gb': 512,
+                                                'memory_mb': 512,
+                                                'ephemeral_gb': 0,
+                                                'vcpus': 1,
+                                                'os_type': 'Linux',
+                                                'uuid': 'fake-uuid',
+                                                'system_metadata': {
+                                                    'preemptible': False
+                                                }}}
+
+        dests = self.driver.select_destinations(self.context, request_spec, {})
+        self.assertEqual(host.host, dests[0]["host"])
+        self.assertEqual(host.nodename, dests[0]["nodename"])


### PR DESCRIPTION
This change adds testing for the opie.scheduler.host_manager module,
fixing some errors arised during the test execution.
